### PR TITLE
Fixing the javadoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target/
 lib/
 upload-jom.xml
 .idea/
+/jom.iml

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 target/
 lib/
 upload-jom.xml
+.idea/

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,9 @@
                             <use>true</use>
                             <version>true</version>
                             <!--<additionalparam>-Xdoclint:none</additionalparam>-->
-                            <additionalparam>-Xdoclint:none</additionalparam>
+                            <!-- Adding Latex parser for javadoc -->
+                            <!--<additionalparam>-header &apos;&lt;script type=&quot;text/javascript&quot; src=&quot;http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML&quot;&gt;&lt;/script&gt;&apos;</additionalparam>-->
+                            <additionalparam>-header &apos;&lt;script type=&quot;text/javascript&quot; src=&quot;http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML&quot;&gt;&lt;/script&gt;&apos;</additionalparam>
                             <sourceFileIncludes>
                                 <include>DoubleMatrixND.java</include>
                                 <include>OptimizationProblem.java</include>

--- a/pom.xml
+++ b/pom.xml
@@ -63,17 +63,25 @@
                             <splitindex>true</splitindex>
                             <use>true</use>
                             <version>true</version>
-                            <!--<additionalparam>-Xdoclint:none</additionalparam>-->
-                            <!-- Adding Latex parser for javadoc -->
-                            <!--<additionalparam>-header &apos;&lt;script type=&quot;text/javascript&quot; src=&quot;http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML&quot;&gt;&lt;/script&gt;&apos;</additionalparam>-->
-                            <additionalparam>-header &apos;&lt;script type=&quot;text/javascript&quot; src=&quot;http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML&quot;&gt;&lt;/script&gt;&apos;</additionalparam>
+                            <!-- Adding Latex parser for Javadoc -->
+                            <additionalparam>
+                                -header &apos;&lt;script type=&quot;text/javascript&quot; src=&quot;http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML&quot;&gt;&lt;/script&gt;&apos;
+                            </additionalparam>
                             <sourceFileIncludes>
                                 <include>DoubleMatrixND.java</include>
                                 <include>OptimizationProblem.java</include>
                                 <include>Expression.java</include>
                                 <include>JOMException.java</include>
                             </sourceFileIncludes>
-                            <sourcepath>src/main/java/com/jom/</sourcepath>
+                            <sourcepath>${project.basedir}/src/main/java/com/jom</sourcepath>
+                            <!-- Adding itself as a dependency in order to find the classes which the sources depend on -->
+                            <additionalDependencies>
+                                <additionalDependency>
+                                    <groupId>${project.groupId}</groupId>
+                                    <artifactId>${project.artifactId}</artifactId>
+                                    <version>${project.version}</version>
+                                </additionalDependency>
+                            </additionalDependencies>
                         </configuration>
                     </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
                             <splitindex>true</splitindex>
                             <use>true</use>
                             <version>true</version>
+                            <!--<additionalparam>-Xdoclint:none</additionalparam>-->
                             <additionalparam>-Xdoclint:none</additionalparam>
                             <sourceFileIncludes>
                                 <include>DoubleMatrixND.java</include>

--- a/src/main/java/com/jom/DoubleMatrixND.java
+++ b/src/main/java/com/jom/DoubleMatrixND.java
@@ -33,7 +33,7 @@ import cern.jet.math.tint.IntFunctions;
  * http://sourceforge.net/projects/parallelcolt/ for more details
  *
  * @author Pablo Pavon Mariño
- * @see http://www.net2plan.com/jom
+ * @see <a href="http://www.net2plan.com/jom">http://www.net2plan.com/jom</a>
  */
 public class DoubleMatrixND
 {
@@ -667,7 +667,7 @@ public class DoubleMatrixND
 
 	/** Returns the matrix cell value at coordinate index. Provided with invalid parameters this method may return invalid objects without throwing
 	 * any exception. You should only use this method when you are absolutely sure that the coordinate is within bounds. Precondition (unchecked):
-	 * index<0 || index>=size().
+	 * \(index {@literal <} 0 \parallel index \ge size()\).
 	 * @param index the index of the cell
 	 * @return the value of the specified cell */
 	public double getQuick(int index)
@@ -683,6 +683,7 @@ public class DoubleMatrixND
 	}
 
 	/** Gets the size of the array in the given dimension
+	 * @param dim Dimension from which the size will be taken.
 	 * @return the size */
 	public int getSize(int dim)
 	{
@@ -911,6 +912,7 @@ public class DoubleMatrixND
 	}
 
 	/** If the array is 3D, returns a DoubleMatrix3D object copying the data in the array
+	 * @param type Type of the matrix.
 	 * @return The DoubleMatrix3D object */
 	public DoubleMatrix3D view3D(String type)
 	{

--- a/src/main/java/com/jom/Expression.java
+++ b/src/main/java/com/jom/Expression.java
@@ -26,7 +26,7 @@ import java.util.Map.Entry;
 /** Expressions objects represent a function of the decision variables defined in its related OptimizationProblem object. JOM creates Expression
  * objects parsing Strings in the JOM syntax.
  * @author Pablo Pavon Mariño
- * @see http://www.net2plan.com/jom
+ * @see <a href="http://www.net2plan.com/jom">http://www.net2plan.com/jom</a>
  * */
 public abstract class Expression
 {
@@ -178,6 +178,7 @@ public abstract class Expression
 	}
 
 	/** Evaluates the given cell in this expression. The expression should be a constant: do not depend from the decision variables
+	 * @param cellIndex Index of the constants that will be evaluated.
 	 * @return an array with the same size as the expression, with the values evaluated in each cell */
 	public final double evaluateConstant(int cellIndex)
 	{

--- a/src/main/java/com/jom/JOMException.java
+++ b/src/main/java/com/jom/JOMException.java
@@ -23,7 +23,7 @@ package com.jom;
 /**
  *
  * @author Pablo Pavon Mariño
- * @see http://www.net2plan.com/jom
+ * @see <a href="http://www.net2plan.com/jom">http://www.net2plan.com/jom</a>
  */
 public class JOMException extends RuntimeException
 {

--- a/src/main/java/com/jom/OptimizationProblem.java
+++ b/src/main/java/com/jom/OptimizationProblem.java
@@ -21,10 +21,11 @@ import java.util.*;
 import java.util.Map.Entry;
 
 /** This class contains the methods for handling optimization problems, defining their input parameters (if any), decision variables,
- * objetive function and constraints, choosing and calling a solver to obtain a numerical solution, and retrieving that solution. 
+ * objetive function and constraints, choosing and calling a solver to obtain a numerical solution, and retrieving that solution.
  * @author Pablo Pavon Mariño
- * @see http://www.net2plan.com/jom
+ * @see <a href="http://www.net2plan.com/jom">http://www.net2plan.com/jom</a>
  */
+
 public class OptimizationProblem
 {
 	final static int MAX_NUMBER_DIMENSIONS_INPUTPARAMETER = 10;
@@ -216,7 +217,7 @@ public class OptimizationProblem
 		return inputParameters.get(name);
 	}
 
-	/** Returns the multipliers of the automatic constraints: x_l <= varName added to the problem, where x_l is the array of lower bounds provided,
+	/** Returns the multipliers of the automatic constraints: {@literal x_l <= varName} added to the problem, where x_l is the array of lower bounds provided,
 	 * associated to the decision variable.
 	 * @param decisionVariableName The name of the decision variable
 	 * @return The multipliers as an array of the same size of the decision variables
@@ -230,7 +231,7 @@ public class OptimizationProblem
 		return new DoubleMatrixND(dv.getVarIds().getSize(), values.copy());
 	}
 
-	/** Returns the multipliers of the automatic constraints: varName <= x_u added to the problem, where x_u is the array of upper bounds provided,
+	/** Returns the multipliers of the automatic constraints: {@literal varName <= x_u} added to the problem, where x_u is the array of upper bounds provided,
 	 * associated to the decision variable.
 	 * @param decisionVariableName The name of the decision variable
 	 * @return The multipliers as an array of the same size of the decision variables

--- a/src/main/java/com/jom/OptimizationProblem.java
+++ b/src/main/java/com/jom/OptimizationProblem.java
@@ -76,7 +76,7 @@ public class OptimizationProblem
 	 *  access the multipliers and other constraint-related info.
 	 * Constraints have the form: expression-left-hand-side connector expression-right-hand-side.
 	 * Expressions are strings that can be evaluated to arrayed expressions of the defined input parameters and decision variables. Connectors must
-	 * be of the type less-equal (<= or =<), greater-equal (>= or =>) or equal (==).
+	 * be of the type less-equal {@literal (<= or =<)}, greater-equal {@literal (>= or =>)} or equal {@literal (==)}.
 	 * @param expression The string expression of the constraint.
 	 * @return The Expression object holding the expression (lhs - rhs), where lhs and rhs are the expression in the left-hand-side and
 	 * right-hand-side of the constraint
@@ -92,7 +92,7 @@ public class OptimizationProblem
 	/** Adds (an array of) constraints to the optimization problem.
 	 * Constraints have the form: expression-left-hand-side connector expression-right-hand-side.
 	 * Expressions are strings that can be evaluated to arrayed expressions of the defined input parameters and decision variables. Connectors must
-	 * be of the type less-equal (<= or =<), greater-equal (>= or =>) or equal (==).
+	 * be of the type less-equal {@literal (<= or =<)}, greater-equal {@literal (>= or =>)} or equal {@literal (==)}.
 	 * @param expression The string expression of the constraint.
 	 * @param identifier A unique string given to identify this constraint
 	 * @return The Expression object holding the expression (lhs - rhs), where lhs and rhs are the expression in the left-hand-side and
@@ -120,6 +120,9 @@ public class OptimizationProblem
 	}
 
 	/** Same as addDecisionVariable(name, isInteger, size, null, null);
+	 * @param name Name of the array of decision variables, as it will used in the expressions.
+	 * @param isInteger True if the decision variables in the array are all constrained to be integer
+	 * @param size One coordinate per dimension of the array, each coordinate is the size of the array in the respective dimension.
 	 */
 	public void addDecisionVariable(String name, boolean isInteger, int[] size)
 	{
@@ -128,6 +131,11 @@ public class OptimizationProblem
 
 	/** addDecisionVariable(String name, boolean isInteger, int[] size, DoubleMatrixND x_l, DoubleMatrixND x_u), but now the lower (upper) bounds
 	 * for all the decision variables in the array are equal to x_l (x_u).
+	 * @param name Name of the array of decision variables, as it will used in the expressions.
+	 * @param isInteger True if the decision variables in the array are all constrained to be integer
+	 * @param size One coordinate per dimension of the array, each coordinate is the size of the array in the respective dimension.
+	 * @param x_l The lower bounds of the variables are created as new DoubleMatrixND (size,x_l)
+	 * @param x_u The upper bounds of the variables are created as new DoubleMatrixND (size,x_u)
 	 */
 	public void addDecisionVariable(String name, boolean isInteger, int[] size, double x_l, double x_u)
 	{
@@ -217,7 +225,7 @@ public class OptimizationProblem
 		return inputParameters.get(name);
 	}
 
-	/** Returns the multipliers of the automatic constraints: {@literal x_l <= varName} added to the problem, where x_l is the array of lower bounds provided,
+	/** Returns the multipliers of the automatic constraints: \(x_l \leq varName\) added to the problem, where \(x_l\) is the array of lower bounds provided,
 	 * associated to the decision variable.
 	 * @param decisionVariableName The name of the decision variable
 	 * @return The multipliers as an array of the same size of the decision variables
@@ -231,7 +239,7 @@ public class OptimizationProblem
 		return new DoubleMatrixND(dv.getVarIds().getSize(), values.copy());
 	}
 
-	/** Returns the multipliers of the automatic constraints: {@literal varName <= x_u} added to the problem, where x_u is the array of upper bounds provided,
+	/** Returns the multipliers of the automatic constraints: \(varName \leq x_u\) added to the problem, where \(x_u\) is the array of upper bounds provided,
 	 * associated to the decision variable.
 	 * @param decisionVariableName The name of the decision variable
 	 * @return The multipliers as an array of the same size of the decision variables
@@ -317,7 +325,7 @@ public class OptimizationProblem
 	}
 
 	/** Returns the slack of the given constraints. It should be zero for equality constraints.
-	 * @param constraintIdentifier
+	 * @param constraintIdentifier Id of the constrain
 	 * @return An array of the same size of the constraints, with the slack values
 	 */
 	public DoubleMatrixND getSlackOfConstraint(String constraintIdentifier)
@@ -330,6 +338,7 @@ public class OptimizationProblem
 	}
 
 	/** Returns true if the given name corresponds to an input parameter defined for the problem
+	 * @param name Name of the input parameter
 	 * @return True if the previous statement is true, false otherwise
 	 */
 	public boolean isInputParameter(String name)


### PR DESCRIPTION
Javadoc building no longer generates neither error nor warnings, eliminating the necesity to ignore JDK 1.8 parsing errors.

- Added a Latex parser for writing math inside the Javadoc.
- Added the project as a dependency for itself to avoid classpath problems.
- Fixed problems with javadoc 1.8 syntax.
- Changed @see labels for hyperlinks.