### PR TITLE
HOTFIX 1: Javadoc generation problems

### DIFF
--- a/JOM-Javadoc/pom.xml
+++ b/JOM-Javadoc/pom.xml
@@ -95,7 +95,7 @@
             <activation>
                 <os>
                     <name>Linux</name>
-                    <family>unix</family>
+                    <family>!windows</family>
                 </os>
             </activation>
             <properties>

--- a/JOM-Javadoc/pom.xml
+++ b/JOM-Javadoc/pom.xml
@@ -91,10 +91,10 @@
     <!-- Especial condition for linux, it needs the allow script in comment parameter -->
     <profiles>
         <profile>
-            <id>Javadoc-Linux</id>
+            <id>Javadoc-Unix</id>
             <activation>
                 <os>
-                    <name>Linux</name>
+                    <name>Unix</name>
                     <family>!windows</family>
                 </os>
             </activation>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # JOM
+[![](https://jitpack.io/v/girtel/JOM.svg)](https://jitpack.io/#girtel/JOM)
+
 Java Optimization Modeler
+
 
 JOM (Java Optimization Modeler) is a free and open-source Java library targeted to allowing Java programs modeling and solving optimization problems, defining their input parameters, decision variables, objective function, and constraints. Mathematical expressions combining decision variables, constant parameters, operators and functions, are defined using a simple MATLAB-like syntax. JOM allows handling multidimensional arrays of variables and constants. This enables, for instance, defining arrays of constraints in a single line of code.
 

--- a/pom.xml
+++ b/pom.xml
@@ -73,5 +73,13 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <!-- Build helper: Version controller -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>2.3</version>
+            </plugin>
+        </plugins>
     </build>
 </project>


### PR DESCRIPTION
- The --allow-script-in-header param seems to be needed depending on maybe the current distribution of linux under use or the current version of Maven. As predicting if it is necessary or not is not possible, it has been left commented in case someone needs it.